### PR TITLE
RuntimeStatus-metric

### DIFF
--- a/src/main/java/no/digipost/monitoring/micrometer/RuntimeStatus.java
+++ b/src/main/java/no/digipost/monitoring/micrometer/RuntimeStatus.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.micrometer;
+
+/**
+ * Values for runtime status.
+ * <p>
+ * You can use the states as metrics values, as well as
+ * the name of the state string to create liveness/readyness
+ * in kubernets, loadbalancer-switching. Or what ever you choose.
+ */
+public class RuntimeStatus {
+
+    private State state = State.STARTING;
+
+    public void set(State newState) {
+        state = newState;
+    }
+
+    public State get() {
+        return state;
+    }
+
+    public enum State {
+        OFFLINE(-2), SHUTTING_DOWN(-1), STARTING(0), ONLINE(1);
+
+        private final int value;
+
+        State(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+}

--- a/src/main/java/no/digipost/monitoring/micrometer/RuntimeStatusBinder.java
+++ b/src/main/java/no/digipost/monitoring/micrometer/RuntimeStatusBinder.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNull;
+
+/**
+ * @see RuntimeStatus for possible values of the metric
+ */
+public class RuntimeStatusBinder implements MeterBinder {
+
+    private RuntimeStatus status;
+
+    public RuntimeStatusBinder(RuntimeStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        Gauge.builder("app_runtime_status", () -> status.get().getValue())
+                .description("State of application with regards the runtime status")
+                .register(registry);
+    }
+}


### PR DESCRIPTION
RuntimeStatus is a metric for saying something about the runtime-state of the application

You might have an application that starts up fairly quicky but then
has to fetch loads of data before it is actually ready to receive load.
For instance: With this metric you can see and check that your loadbalancer
is doing the correct thing and only sending requests when online
or you can correlate state with api-errors.