### PR TITLE
Make DatabaseConnectionPool generic as a PoolMetric

### DIFF
--- a/src/main/java/no/digipost/monitoring/micrometer/PoolStats.java
+++ b/src/main/java/no/digipost/monitoring/micrometer/PoolStats.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package no.digipost.monitoring.db;
+package no.digipost.monitoring.micrometer;
 
 /**
  * This interface need to be implemented for your specific


### PR DESCRIPTION
Anyways: The former implementation could not be used together with
DatabaseAvailabilityMetrics since they had the same metric name
but different tags.