### PR TITLE
don't crash if someone calls the program with commandline arguments

### DIFF
--- a/src/main/java/no/digipost/monitoring/micrometer/JarManifest.java
+++ b/src/main/java/no/digipost/monitoring/micrometer/JarManifest.java
@@ -23,7 +23,7 @@ class JarManifest extends Manifest {
 
     JarManifest() throws ClassNotFoundException {
         this(
-                Class.forName((String) System.getProperties().get("sun.java.command"), true, Thread.currentThread().getContextClassLoader())
+                Class.forName(((String) System.getProperties().get("sun.java.command")).split(" ")[0], true, Thread.currentThread().getContextClassLoader())
         );
     }
 


### PR DESCRIPTION
if any java app is started with commandline arguments, `System.getProperties().get("sun.java.command")` will include those arguments - preventing `Class.forName(...)` from finding the correct class.

Some of our apps (`dpost-migrering`) are always ran with commandline arguments