### PR TITLE
Fix a classic gotcha when using Micrometer where the value gets GC-ed in runtime

### DIFF
--- a/src/main/java/no/digipost/monitoring/event/EventsThreshold.java
+++ b/src/main/java/no/digipost/monitoring/event/EventsThreshold.java
@@ -16,5 +16,5 @@
 package no.digipost.monitoring.event;
 
 public interface EventsThreshold {
-    double getOneMinuteThreshold();
+    Number getOneMinuteThreshold();
 }

--- a/src/main/java/no/digipost/monitoring/event/OneMinuteEventsThreshold.java
+++ b/src/main/java/no/digipost/monitoring/event/OneMinuteEventsThreshold.java
@@ -17,7 +17,7 @@ package no.digipost.monitoring.event;
 
 public class OneMinuteEventsThreshold implements EventsThreshold {
 
-    private double threshold;
+    private Double threshold;
 
     private OneMinuteEventsThreshold(double threshold) {
         this.threshold = threshold;
@@ -32,7 +32,7 @@ public class OneMinuteEventsThreshold implements EventsThreshold {
     }
 
     @Override
-    public double getOneMinuteThreshold() {
+    public Number getOneMinuteThreshold() {
         return threshold;
     }
 }

--- a/src/test/java/no/digipost/monitoring/event/AppBusinessEventLoggerTest.java
+++ b/src/test/java/no/digipost/monitoring/event/AppBusinessEventLoggerTest.java
@@ -69,6 +69,14 @@ public class AppBusinessEventLoggerTest {
         assertThat(prometheusRegistry.scrape(), containsString("app_business_events_1min_error_thresholds{name=\"VIOLATION_WITH_WARN_AND_ERROR\",} 5.0"));
     }
 
+    @Test
+    void check_that_values_are_not_GCed() {
+        eventLogger.log(MyBusinessEvents.VIOLATION_WITH_WARN_AND_ERROR, 1337);
+        Runtime.getRuntime().gc();
+        
+        assertThat(prometheusRegistry.scrape(), not(containsString("NaN")));
+    }
+
     private enum MyBusinessEvents implements AppBusinessEvent {
         VIOLATION,
         VIOLATION_WITH_WARN(OneMinuteEventsThreshold.perDay(7200)),


### PR DESCRIPTION
Micrometer gauges does not retain the actual object you pass in for it
 self. So as long as that object is not GC-ed, you are good.
In this implementation, I thought that I was in the clear since
the `OneMinuteEventsThreshold.perMinute(1)` usage is in an enum, which
is instantiated as singletons and thus is not GC-ed.

The gotcha is of course that when we return the primitive `double`, is
is not a reference but a copy of the actual bit that represent the primitive.
Thus, this gets GC-ed.

Anyhooo, By calling `Runtime.getRuntime().gc();` in the test we can
verify this behavour.