### PR TITLE
Adding ActiveRequestsFilter to track long-running requests

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,6 +15,7 @@ This project includes:
   Digipost Digg under The Apache Software License, Version 2.0
   digipost-micrometer-prometheus under Apache License, Version 2.0
   HdrHistogram under Public Domain, per Creative Commons CC0 or BSD-2-Clause
+  Java Servlet API under CDDL + GPLv2 with classpath exception
   LatencyUtils under Public Domain, per Creative Commons CC0
   micrometer-core under The Apache Software License, Version 2.0
   micrometer-registry-prometheus under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,14 @@
             <version>1.3.2</version>
         </dependency>
 
+        <!-- Optional dependencies -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -106,6 +114,9 @@
                                 <version>3.3.1</version>
                             </requireMavenVersion>
                             <bannedDependencies>
+                                <includes>
+                                    <include>javax.servlet</include>
+                                </includes>
                                 <excludes>
                                     <exclude>javax.*</exclude>
                                     <exclude>org.hamcrest:hamcrest-core</exclude>

--- a/src/main/java/no/digipost/monitoring/servlet/ActiveRequestsFilter.java
+++ b/src/main/java/no/digipost/monitoring/servlet/ActiveRequestsFilter.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.servlet;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+public class ActiveRequestsFilter implements Filter {
+    final Map<UUID, RequestMetaInfo> activeRequests = new ConcurrentHashMap<>();
+    private final Config config;
+
+    public ActiveRequestsFilter(MeterRegistry registry, ActiveRequestsFilter.Config config) {
+        this.config = config;
+        registry.gauge("app_http_requests_active", activeRequests, Map::size);
+        registry.gauge("app_http_requests_max", config.getMaxThreads());
+
+        registry.gauge("app_http_requests_longrunning", emptyList(), activeRequests,
+                (Map<UUID, RequestMetaInfo> activeRequests) -> getLongRunning(activeRequests, config.longRunningThreshold).size());
+    }
+
+    @Override
+    public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
+        UUID requestId = UUID.randomUUID();
+        RequestMetaInfo metaInfo = createRequestMetaInfo(servletRequest, Instant.now());
+        try {
+            activeRequests.put(requestId, metaInfo);
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            activeRequests.remove(requestId);
+        }
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void destroy() {}
+
+    private boolean excludedRequest(RequestMetaInfo requestMetaInfo) {
+        return config.longRunningExclusions.stream().anyMatch(p -> p.test(requestMetaInfo));
+    }
+
+    private List<RequestMetaInfo> getLongRunning(Map<UUID, RequestMetaInfo> activeRequests, Duration longRunningThreshold) {
+        Instant deadline = Instant.now().minus(longRunningThreshold);
+        return activeRequests.values().stream()
+                .filter(m -> m.isOlderThan(deadline) && !excludedRequest(m))
+                .collect(toList());
+    }
+
+    private static RequestMetaInfo createRequestMetaInfo(ServletRequest servletRequest, Instant now) {
+        if (servletRequest instanceof HttpServletRequest) {
+            HttpServletRequest httpReq = (HttpServletRequest) servletRequest;
+            String path = httpReq.getRequestURI();
+            String method = httpReq.getMethod();
+            return new RequestMetaInfo(path, method, now);
+        } else {
+            return new RequestMetaInfo();
+        }
+    }
+
+
+    public static class RequestMetaInfo {
+        public final String path;
+        public final String method;
+        public final Instant requestTime;
+
+        public RequestMetaInfo(String path, String method, Instant requestTime) {
+            this.path = path;
+            this.method = method;
+            this.requestTime = requestTime;
+        }
+
+        public RequestMetaInfo() {
+            this("?","?", Instant.now());
+        }
+
+        public boolean isOlderThan(Instant deadline) {
+            return requestTime.isBefore(deadline);
+        }
+
+        @Override
+        public String toString() {
+            return requestTime.toString() + " " + method + " " + path;
+        }
+    }
+
+    public static class Config {
+        private Duration longRunningThreshold = Duration.ofMinutes(1);
+        private int maxThreads;
+        private List<Predicate<RequestMetaInfo>> longRunningExclusions = emptyList();
+
+        private Config(int maxThreads) {
+            this.maxThreads = maxThreads;
+        }
+
+        public static Config forMaxThreads(int maxThreads) {
+            return new Config(maxThreads);
+        }
+
+        public Config longRunningThreshold(Duration longRunningThreshold) {
+            this.longRunningThreshold = longRunningThreshold;
+            return this;
+        }
+
+        public Config longRunningExclusions(List<Predicate<RequestMetaInfo>> longRunningExclusions) {
+            this.longRunningExclusions = longRunningExclusions;
+            return this;
+        }
+
+        public int getMaxThreads() {
+            return maxThreads;
+        }
+    }
+}

--- a/src/test/java/no/digipost/monitoring/servlet/ActiveRequestsFilterTest.java
+++ b/src/test/java/no/digipost/monitoring/servlet/ActiveRequestsFilterTest.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 
+import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
 import static no.digipost.monitoring.servlet.ActiveRequestsFilter.Config.forMaxThreads;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -57,7 +58,7 @@ class ActiveRequestsFilterTest {
     void test_longrunning() {
         unit = new ActiveRequestsFilter(prometheusRegistry, forMaxThreads(10).longRunningThreshold(LONG_RUNNING_THRESHOLD));
 
-        simulateRequest("/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD));
+        simulateRequest("/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD).minus(ofSeconds(1)));
 
         assertActive("1.0");
         assertLongRunning("1.0");
@@ -69,8 +70,8 @@ class ActiveRequestsFilterTest {
                         .longRunningThreshold(LONG_RUNNING_THRESHOLD)
                         .longRunningExclusions(singletonList(r -> r.path.equals("/hello"))));
 
-        simulateRequest( "/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD));
-        simulateRequest( "/another", Instant.now().minus(LONG_RUNNING_THRESHOLD));
+        simulateRequest( "/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD).minus(ofSeconds(1)));
+        simulateRequest( "/another", Instant.now().minus(LONG_RUNNING_THRESHOLD).minus(ofSeconds(1)));
 
         assertActive("2.0");
         assertLongRunning("1.0");

--- a/src/test/java/no/digipost/monitoring/servlet/ActiveRequestsFilterTest.java
+++ b/src/test/java/no/digipost/monitoring/servlet/ActiveRequestsFilterTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.servlet;
+
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import no.digipost.monitoring.servlet.ActiveRequestsFilter.RequestMetaInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static no.digipost.monitoring.servlet.ActiveRequestsFilter.Config.forMaxThreads;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ActiveRequestsFilterTest {
+
+    public static final Duration LONG_RUNNING_THRESHOLD = Duration.ofMinutes(1);
+    private PrometheusMeterRegistry prometheusRegistry;
+    private ActiveRequestsFilter unit;
+
+    @BeforeEach
+    void setUp() {
+        this.prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+
+    @Test
+    void test_active() {
+        unit = new ActiveRequestsFilter(prometheusRegistry, forMaxThreads(10));
+
+        simulateRequest("/hello", Instant.now());
+        simulateRequest("/hello", Instant.now());
+
+        assertActive("2.0");
+        assertMax("10.0");
+        assertLongRunning("0.0");
+    }
+
+    @Test
+    void test_longrunning() {
+        unit = new ActiveRequestsFilter(prometheusRegistry, forMaxThreads(10).longRunningThreshold(LONG_RUNNING_THRESHOLD));
+
+        simulateRequest("/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD));
+
+        assertActive("1.0");
+        assertLongRunning("1.0");
+    }
+
+    @Test
+    void test_longrunning_excluded() {
+        unit = new ActiveRequestsFilter(prometheusRegistry, forMaxThreads(10)
+                        .longRunningThreshold(LONG_RUNNING_THRESHOLD)
+                        .longRunningExclusions(singletonList(r -> r.path.equals("/hello"))));
+
+        simulateRequest( "/hello", Instant.now().minus(LONG_RUNNING_THRESHOLD));
+        simulateRequest( "/another", Instant.now().minus(LONG_RUNNING_THRESHOLD));
+
+        assertActive("2.0");
+        assertLongRunning("1.0");
+    }
+
+    private void simulateRequest(String path, Instant requestReceived) {
+        unit.activeRequests.put(UUID.randomUUID(), new RequestMetaInfo(path, "GET", requestReceived));
+    }
+
+    private void assertActive(String value) {
+        assertThat(prometheusRegistry.scrape(), containsString("app_http_requests_active " + value));
+    }
+
+    private void assertMax(String value) {
+        assertThat(prometheusRegistry.scrape(), containsString("app_http_requests_max " + value));
+    }
+
+    private void assertLongRunning(String value) {
+        assertThat(prometheusRegistry.scrape(), containsString("app_http_requests_longrunning " + value));
+    }
+
+}


### PR DESCRIPTION
## Metrics

```
app_http_requests_active
app_http_requests_max
app_http_requests_longrunning
```

## Usage

```
new ActiveRequestsFilter(registry, Config.forMaxThreads(MAX_REQUESTS).longRunningExclusions(Collections.singletonList(IS_BATCH_POST_REQUEST)))
```