### PR TITLE
Metrics for selected logback logger only

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -15,7 +15,6 @@ This project includes:
   Digipost Digg under The Apache Software License, Version 2.0
   digipost-micrometer-prometheus under Apache License, Version 2.0
   HdrHistogram under Public Domain, per Creative Commons CC0 or BSD-2-Clause
-  Java Servlet API under CDDL + GPLv2 with classpath exception
   LatencyUtils under Public Domain, per Creative Commons CC0
   micrometer-core under The Apache Software License, Version 2.0
   micrometer-registry-prometheus under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <logback.version>1.2.3</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -63,6 +64,24 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
             <optional>true</optional>
         </dependency>
 
@@ -234,6 +253,7 @@
                 <artifactId>maven-notice-plugin</artifactId>
                 <version>1.1.0</version>
                 <configuration>
+                    <excludeOptional>true</excludeOptional>
                     <excludeScopes>
                         <excludeScope>test</excludeScope>
                     </excludeScopes>

--- a/src/main/java/no/digipost/monitoring/logging/LogbackLoggerMetrics.java
+++ b/src/main/java/no/digipost/monitoring/logging/LogbackLoggerMetrics.java
@@ -25,6 +25,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Log-events metrics for specified logback appender. Dimensions for <code>level</code>, <code>logger</code>
+ * <p>
+ * USAGE:
+ * <pre>
+ * LogbackLoggerMetrics.forRootLogger().bindTo(meterRegistry);
+ * </pre>
+ */
 public class LogbackLoggerMetrics implements MeterBinder {
 
     private final LoggerContext loggerContext;
@@ -71,6 +79,9 @@ public class LogbackLoggerMetrics implements MeterBinder {
                 .register(registry);
     }
 
+    /**
+     * Based on https://github.com/prometheus/client_java/blob/master/simpleclient_logback/src/main/java/io/prometheus/client/logback/InstrumentedAppender.java
+     */
     private class MetricsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         @Override
         public void start() {

--- a/src/main/java/no/digipost/monitoring/logging/LogbackLoggerMetrics.java
+++ b/src/main/java/no/digipost/monitoring/logging/LogbackLoggerMetrics.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.slf4j.LoggerFactory;
+
+public class LogbackLoggerMetrics implements MeterBinder {
+
+    private final LoggerContext loggerContext;
+    private final String loggerName;
+    private Counter traceCounter;
+    private Counter debugCounter;
+    private Counter infoCounter;
+    private Counter warnCounter;
+    private Counter errorCounter;
+
+    private LogbackLoggerMetrics(String loggerName) {
+        this.loggerName = loggerName;
+        loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+    }
+
+    public static LogbackLoggerMetrics forRootLogger() {
+        return new LogbackLoggerMetrics(Logger.ROOT_LOGGER_NAME);
+    }
+
+    public static LogbackLoggerMetrics forLogger(String loggerName) {
+        return new LogbackLoggerMetrics(loggerName);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        traceCounter = createCounter(registry, "trace");
+        debugCounter = createCounter(registry, "debug");
+        infoCounter = createCounter(registry, "info");
+        warnCounter = createCounter(registry, "warn");
+        errorCounter = createCounter(registry, "error");
+
+        Logger logger = loggerContext.getLogger(loggerName);
+        MetricsAppender metricsAppender = new MetricsAppender();
+        metricsAppender.setContext(loggerContext);
+        metricsAppender.start();
+
+        logger.addAppender(metricsAppender);
+    }
+
+    private Counter createCounter(MeterRegistry registry, String level) {
+        return Counter.builder("logback_logger_events")
+                .tag("logger", loggerName)
+                .tag("level", level)
+                .register(registry);
+    }
+
+    private class MetricsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+        @Override
+        public void start() {
+            super.start();
+        }
+
+        @Override
+        protected void append(ILoggingEvent event) {
+            try {
+                switch (event.getLevel().toInt()) {
+                    case Level.TRACE_INT:
+                        traceCounter.increment();
+                        break;
+                    case Level.DEBUG_INT:
+                        debugCounter.increment();
+                        break;
+                    case Level.INFO_INT:
+                        infoCounter.increment();
+                        break;
+                    case Level.WARN_INT:
+                        warnCounter.increment();
+                        break;
+                    case Level.ERROR_INT:
+                        errorCounter.increment();
+                        break;
+                    default:
+                        break;
+                }
+            } catch (Exception e) {
+                // Guard against increment-exceptions causing more logging (however unlikely)
+            }
+        }
+
+    }
+}

--- a/src/test/java/no/digipost/monitoring/LogbackLoggerMetricsTest.java
+++ b/src/test/java/no/digipost/monitoring/LogbackLoggerMetricsTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import no.digipost.monitoring.logging.LogbackLoggerMetrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class LogbackLoggerMetricsTest {
+
+    private PrometheusMeterRegistry prometheusRegistry;
+
+    @BeforeEach
+    void setUp() {
+        this.prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+
+
+    @Test
+    void test_named_logger() {
+        LogbackLoggerMetrics.forLogger("test").bindTo(prometheusRegistry);
+
+        LoggerFactory.getLogger("test").warn("warn");
+        LoggerFactory.getLogger("test.sublevel").warn("warn");
+        LoggerFactory.getLogger("test").error("error");
+        LoggerFactory.getLogger("another.logger").error("another error");
+
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"warn\",logger=\"test\",} 2.0"));
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"error\",logger=\"test\",} 1.0"));
+    }
+
+    @Test
+    void test_root_logger() {
+        LogbackLoggerMetrics.forRootLogger().bindTo(prometheusRegistry);
+
+        LoggerFactory.getLogger("test").error("error");
+        LoggerFactory.getLogger("test").warn("warn");
+
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"warn\",logger=\"ROOT\",} 1.0"));
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"error\",logger=\"ROOT\",} 1.0"));
+    }
+
+    @Test
+    void test_both_root_and_named_logger() {
+        LogbackLoggerMetrics.forRootLogger().bindTo(prometheusRegistry);
+        LogbackLoggerMetrics.forLogger("test").bindTo(prometheusRegistry);
+
+        LoggerFactory.getLogger("test").error("error"); // counted by both
+        LoggerFactory.getLogger("another.logger").error("error"); // counted by root
+
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"error\",logger=\"ROOT\",} 2.0"));
+        assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"error\",logger=\"test\",} 1.0"));
+    }
+
+}


### PR DESCRIPTION
What do you guys think? Had some trouble with `LogbackMetrics` counting irrelevant events, for example events that went to a logger with `additivity=false` (i.e. not root-logger), so trying another approach, making it possible to specify which logger you are counting events for.

```
logback_logger_events_total{level="error",logger="test",} 1.0
logback_logger_events_total{level="error",logger="ROOT",} 1.0
```

The normal case will be counting events for the root-logger I think.

Also, excluding notice for optional dependencies as they are provided by the user.