### PR TITLE
Fix bug where exception was swallowed if AppStatus was not FAILED.

### DIFF
--- a/src/main/java/no/digipost/monitoring/thirdparty/TimedThirdPartyCall.java
+++ b/src/main/java/no/digipost/monitoring/thirdparty/TimedThirdPartyCall.java
@@ -64,12 +64,12 @@ public class TimedThirdPartyCall<RESULT> {
 
         if (AppStatus.FAILED == reportWarnPredicate.apply(returnValue, thrown)) {
             descriptor.failedCounter.increment();
-            if (thrown.isPresent()) throw thrown.get();
         } else if (AppStatus.WARN == reportWarnPredicate.apply(returnValue, thrown)) {
             descriptor.warnCounter.increment();
         } else {
             descriptor.successCounter.increment();
         }
+        if (thrown.isPresent()) throw thrown.get();
 
         return returnValue;
     }


### PR DESCRIPTION
Exception should be thrown without regards to the appStatus. The old flow suggested that an exception only was expected to be thrown if the predicate judged the call to be AppStatus.Failed (based on returnValue and the exception). This may not always be the case e.g. an network exception where the exception may act as a retry-flag and we don't want to alert on it (i.e. AppStatus.OK)