### PR TITLE
Set ApplicationInfoMetric tags from env if not available in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Usage in a `MeterRegistry`:
 new ApplicationInfoMetrics().bindTo(this);
 ```
 
-Application metric with data from `MANIFEST.MF`.
+Application metric with data from `MANIFEST.MF` or environment variables.
 
-This is what is expected to exist in the manifest:
+This is what is expected to exist in the manifest or as key value environment variables:
 
 ```
 Build-Jdk-Spec: 12
@@ -29,6 +29,13 @@ This will create this metric in Prometheus running java 11:
 # TYPE app_info gauge
 app_info{application="my-application",buildNumber="ffb9099",buildTime="2019-12-19T22:52:05+0100",buildVersion="1.2.3",javaBuildVersion="12",javaVersion="11",} 1.0
 ```
+
+The following metric will be created if no values are present in the manifest or environment variables:
+```
+# HELP app_info General build and runtime information about the application. This is a static value
+# TYPE app_info gauge
+app_info{javaVersion="11",} 1.0
+```  
 
 ## Simple Prometheus server
 
@@ -155,6 +162,7 @@ name. For this eksample that is `VIOLATION_WITH_WARN` which is your uniqe event 
 Log-events metrics for specified logback appender. Dimensions for level and logger.
 ```java
 LogbackLoggerMetrics.forRootLogger().bindTo(meterRegistry);
+//or
 LogbackLoggerMetrics.forLogger("my.logger.name").bindTo(meterRegistry);
 ```
 
@@ -191,7 +199,7 @@ logger_events_5min_threshold{application="my-application",level="error",logger="
 
 These metrics can be used for alerting in combination with the metrics above. Prometheus expression:
 ```
-sum by (job,name,level,logger) (increase(logback_logger_events_total[5m]))
+sum by (job,level,logger) (increase(logback_logger_events_total[5m]))
 >=
-max by (job,name,level,logger) (log_events_5min_threshold)
+max by (job,level,logger) (log_events_5min_threshold)
 ```

--- a/src/test/java/no/digipost/monitoring/micrometer/ApplicationInfoMetricsTest.java
+++ b/src/test/java/no/digipost/monitoring/micrometer/ApplicationInfoMetricsTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.monitoring.micrometer;
+
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+class ApplicationInfoMetricsTest {
+
+    private PrometheusMeterRegistry prometheusRegistry;
+
+    @BeforeEach
+    void setUp() {
+        this.prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+
+    @Test
+    public void shouldNotThrowErrorIfManifestValuesDontExists(){
+        try {
+            ApplicationInfoMetrics applicationInfoMetrics = new ApplicationInfoMetrics(ApplicationInfoMetricsTest.class);
+            applicationInfoMetrics.bindTo(prometheusRegistry);
+            System.out.println(prometheusRegistry.scrape());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
New: Application info metrics tags can be specified with environmental variables and not only from MANIFEST.MF.

Not all application run from inside a jar, thus MANIFEST.MF is not always available. This commit enables the application to define the variables via env instead.