### PR TITLE
Add support to exclude a logger from logback_logger_events-metrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ logback_logger_events_total{application="my-application",level="info",logger="RO
 logback_logger_events_total{application="my-application",level="debug",logger="ROOT",} 0.0
 ```
 
+### Excluding logger from metric
+
+If you for some reasons don't want log events from a spesific logger to be included in the metric this can be done:
+
+```java
+LogbackLoggerMetrics.forRootLogger()
+    .excludeLogger("ignored.logger.name")
+    .bindTo(prometheusRegistry);
+```
+
 ### Thresholds
 
 Metrics for logging level threshold can also be created with the methods `warnThreshold5min` and `errorThreshold5min`.

--- a/src/test/java/no/digipost/monitoring/LogbackLoggerMetricsTest.java
+++ b/src/test/java/no/digipost/monitoring/LogbackLoggerMetricsTest.java
@@ -72,10 +72,14 @@ public class LogbackLoggerMetricsTest {
     }
 
     @Test
-    void test_excluded_logger_should_not_be_included_in_count() {
-        LogbackLoggerMetrics.forRootLogger().excludeLogger("ignored").bindTo(prometheusRegistry);
+    void test_excluded_loggers_should_not_be_included_in_count() {
+        LogbackLoggerMetrics.forRootLogger()
+                .excludeLogger("ignored")
+                .excludeLogger("also.ignored")
+                .bindTo(prometheusRegistry);
 
         LoggerFactory.getLogger("ignored").error("error");
+        LoggerFactory.getLogger("also.ignored").error("error");
         LoggerFactory.getLogger("another.logger").error("error"); // counted by root
 
         assertThat(prometheusRegistry.scrape(), containsString("logback_logger_events_total{level=\"error\",logger=\"ROOT\",} 1.0"));


### PR DESCRIPTION
Sometimes there is a logger that you don't want to include in your metrics. It may be because that it is noisy and you don't have time to deal with it right now.

Future improvement: Exclude log events based on mdc field and predicate