### PR TITLE
Support overriding of manifest values through sys. props or env. vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.iml
 target/
+/.classpath
+/.project

--- a/src/test/java/no/digipost/monitoring/micrometer/ApplicationInfoMetricsTest.java
+++ b/src/test/java/no/digipost/monitoring/micrometer/ApplicationInfoMetricsTest.java
@@ -17,9 +17,13 @@ package no.digipost.monitoring.micrometer;
 
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -43,4 +47,19 @@ class ApplicationInfoMetricsTest {
             fail();
         }
     }
+
+    @Test
+    void shouldOverrideManifestValueWithSystemProperty() {
+        ApplicationInfoMetrics applicationInfoMetrics = new ApplicationInfoMetrics(Logger.class);
+        String app = "NotMyApp";
+        try {
+            System.setProperty("Implementation-Title", app);
+            applicationInfoMetrics.bindTo(prometheusRegistry);
+        } finally {
+            System.getProperties().remove("Implementation-Title");
+        }
+        String scrapeResult = prometheusRegistry.scrape();
+        assertThat(scrapeResult, containsString(String.format("application=\"%s\"", app)));
+    }
+
 }


### PR DESCRIPTION
The use case is somewhat unusual, but nevertheless difficult to solve without 
an ability to override Micrometer tags in this library: You need to deploy the 
same application (with the same JARs and manifest files) multiple times 
with varying configuration, but you want to distinguish metrics from the 
different deployments. This was not possible prior to this change, since the 
`application` tag was always set from the manifest of the apps main JAR
(env. vars was only consulted when no manifest was found, which is not 
normally the case).

## Solution Proposal

Always check system properties and environment variables before
consulting the JAR file manifest (was: fallback to env. vars only when
manifest was not found).