### PR TITLE
Allow creating AppBusinessEvent with lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 /.classpath
 /.project
+.idea

--- a/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
+++ b/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
@@ -41,7 +41,14 @@ import java.util.Optional;
  * </code>
  */
 public interface AppBusinessEvent {
+
     String getName();
-    Optional<EventsThreshold> getWarnThreshold();
-    Optional<EventsThreshold> getErrorThreshold();
+
+    default Optional<EventsThreshold> getWarnThreshold() {
+        return Optional.empty();
+    }
+
+    default Optional<EventsThreshold> getErrorThreshold() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
If you're not interested in alarm thresholds, it is nice to be able to create AppBusinessEvents with lambda expressions, which will only implement the getName() method. This is not possible when you have to implement all three methods. Since the thresholds return Optionals, I think it makes sense to make default implementations that return Optional.empty().