### PR TITLE
Catch all thrown stuff in AsyncUpdater

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,5 +20,4 @@ This software includes third party software subject to the following licenses:
   Prometheus Metrics Exposition Formats under The Apache Software License, Version 2.0
   Prometheus Metrics Model under The Apache Software License, Version 2.0
   Prometheus Metrics Tracer Common under The Apache Software License, Version 2.0
-  Shaded Protobuf under The Apache Software License, Version 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -172,7 +172,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -196,31 +196,31 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.2</version>
                     <configuration>
                         <argLine>-Djava.util.logging.config.file=/logging.properties</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>2.18.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jasig.maven</groupId>
@@ -230,12 +230,12 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.5</version>
+                    <version>4.6</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.21.2</version>
+                    <version>0.23.1</version>
                     <configuration>
                         <parameter>
                             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <maven.compiler.release>11</maven.compiler.release>
-        <logback.version>1.4.14</logback.version>
+        <logback.version>1.5.17</logback.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -50,21 +50,28 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-bom</artifactId>
-                <version>1.13.1</version>
+                <version>1.14.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-bom</artifactId>
+                <version>2.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.11.0-M2</version>
+                <version>5.12.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>5.12.0</version>
+                <version>5.16.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -103,7 +110,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.13</version>
             <optional>true</optional>
         </dependency>
 
@@ -125,7 +131,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -148,7 +154,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.34</version>
+            <version>0.36</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/digipost/monitoring/async/AsyncUpdater.java
+++ b/src/main/java/no/digipost/monitoring/async/AsyncUpdater.java
@@ -18,8 +18,9 @@ package no.digipost.monitoring.async;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
 
 class AsyncUpdater implements Runnable {
 
@@ -46,8 +47,10 @@ class AsyncUpdater implements Runnable {
             updateNewValues.run();
             lastUpdate = clock.instant();
             lastUpdateSuccessful = true;
-        } catch (Exception e) {
-            LOG.log(Level.WARNING, "Unexpected exception in updater '" + updaterName + "' while updating metrics.", e);
+        } catch (Throwable e) {
+            LOG.log(WARNING,
+                    "Unexpected exception in updater '" + updaterName + "' while updating metrics: " +
+                    e.getClass().getSimpleName() + " " + e.getMessage(), e);
             lastUpdateSuccessful = false;
         }
     }


### PR DESCRIPTION
For å beskytte fixed rate scheduling fra å bli avbrutt. Eneste interessante commit er [5995073](https://github.com/digipost/digipost-micrometer-prometheus/pull/36/commits/59950730877fe838cb3007bf29fa47a4def0a1db)