### PR TITLE
Support additional tags provided by AppBusinessEvent

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -18,6 +18,8 @@ This software includes third party software subject to the following licenses:
   Prometheus Metrics Config under The Apache Software License, Version 2.0
   Prometheus Metrics Core under The Apache Software License, Version 2.0
   Prometheus Metrics Exposition Formats under The Apache Software License, Version 2.0
+  Prometheus Metrics Exposition Text Formats under The Apache Software License, Version 2.0
   Prometheus Metrics Model under The Apache Software License, Version 2.0
   Prometheus Metrics Tracer Common under The Apache Software License, Version 2.0
+  SLF4J API Module under MIT
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <properties>
         <maven.compiler.release>11</maven.compiler.release>
-        <logback.version>1.5.17</logback.version>
+        <logback.version>1.5.18</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-bom</artifactId>
-                <version>1.14.1</version>
+                <version>1.15.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -64,14 +64,14 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.12.0</version>
+                <version>5.13.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>5.16.0</version>
+                <version>5.19.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -154,7 +153,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.36</version>
+            <version>0.38</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
+++ b/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
@@ -17,6 +17,8 @@ package no.digipost.monitoring.event;
 
 import io.micrometer.core.instrument.Tag;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -92,4 +94,19 @@ public interface AppBusinessEvent {
     Optional<EventsThreshold> getWarnThreshold();
 
     Optional<EventsThreshold> getErrorThreshold();
+
+    /**
+     * Get any additional tags to include in this event.
+     * <p>
+     * <strong>Note:</strong> any tag returned by this is treated with lower
+     * precedence than tags reserved for AppBusinessEventLogger to set as part
+     * of its operation. E.g. if you return the mapping {@code name="SOME_NAME"},
+     * this will be silently discarded (it may be logged as a invalid use of the API),
+     * as the value from {@link #getName()} takes precedence.
+     *
+     * @return the additional tag to include in this event
+     */
+    default Map<String, String> getAdditionalTags() {
+        return Collections.emptyMap();
+    }
 }

--- a/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
+++ b/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
@@ -45,6 +45,42 @@ import java.util.Optional;
 public interface AppBusinessEvent {
 
     /**
+     * A variant of {@link AppBusinessEvent} meant for events
+     * implemented as {@code enum}s, and the {@link Enum#name() name}
+     * of the {@code enum} is the event's {@link #getName() name}.
+     */
+    interface NamedAsEnum extends AppBusinessEvent {
+
+        @Override
+        default String getName() {
+            return name();
+        }
+
+        String name();
+    }
+
+    /**
+     * A variant of {@link AppBusinessEvent} meant for informational
+     * events which are not designed to trigger errors and warnings,
+     * or may trigger alarms based on other externally defined rules.
+     *
+     * The {@link #getWarnThreshold()} and {@link #getErrorThreshold()}
+     * are both implemented to return {@link Optional#empty() no threshold}.
+     */
+    interface Informational extends AppBusinessEvent {
+        @Override
+        default Optional<EventsThreshold> getWarnThreshold() {
+            return Optional.empty();
+        }
+
+        @Override
+        default Optional<EventsThreshold> getErrorThreshold() {
+            return Optional.empty();
+        }
+    }
+
+
+    /**
      * Get the name of this event. This will result in the
      * {@link Tag} {@code name=getName()} to be included in the event when
      * registered with an {@link AppBusinessEventLogger}.

--- a/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
+++ b/src/main/java/no/digipost/monitoring/event/AppBusinessEvent.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.monitoring.event;
 
+import io.micrometer.core.instrument.Tag;
+
 import java.util.Optional;
 
 /**
@@ -22,10 +24,10 @@ import java.util.Optional;
  * event with an optional alerting threshold.
  *
  * Example:
- * <code> 
+ * <code>
  * public enum MyEvent implements AppBusinessEvent{
  *     VIOLATION_WITH_WARN_AND_ERROR;
- *     
+ *
  *  public String getName() {
  *      return name();
  *  }
@@ -41,7 +43,17 @@ import java.util.Optional;
  * </code>
  */
 public interface AppBusinessEvent {
+
+    /**
+     * Get the name of this event. This will result in the
+     * {@link Tag} {@code name=getName()} to be included in the event when
+     * registered with an {@link AppBusinessEventLogger}.
+     *
+     * @return the name of the event.
+     */
     String getName();
+
     Optional<EventsThreshold> getWarnThreshold();
+
     Optional<EventsThreshold> getErrorThreshold();
 }

--- a/src/main/java/no/digipost/monitoring/event/AppBusinessEventLogger.java
+++ b/src/main/java/no/digipost/monitoring/event/AppBusinessEventLogger.java
@@ -17,23 +17,29 @@ package no.digipost.monitoring.event;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * EventLogger-implementation for metrics with gauges for warns and errors
  *
- * You need to implement the logic for the actual events your self. 
+ * You need to implement the logic for the actual events your self.
  *
  * @see AppBusinessEvent for more information.
  *
  * Example output:
- * # HELP app_business_events_1min_warn_thresholds  
+ * # HELP app_business_events_1min_warn_thresholds
  * # TYPE app_business_events_1min_warn_thresholds gauge
  * app_business_events_1min_warn_thresholds{name="VIOLATION_WITH_WARN_AND_ERROR",} 5.0
- * # HELP app_business_events_total  
+ * # HELP app_business_events_total
  * # TYPE app_business_events_total counter
  * app_business_events_total{name="VIOLATION_WITH_WARN_AND_ERROR",} 1.0
- * # HELP app_business_events_1min_error_thresholds  
+ * # HELP app_business_events_1min_error_thresholds
  * # TYPE app_business_events_1min_error_thresholds gauge
  * app_business_events_1min_error_thresholds{name="VIOLATION_WITH_WARN_AND_ERROR",} 5.0
  *
@@ -46,6 +52,8 @@ import io.micrometer.core.instrument.Tags;
  */
 public class AppBusinessEventLogger implements EventLogger {
 
+    private static final Logger LOG = LoggerFactory.getLogger(AppBusinessEventLogger.class);
+
     static final String METRIC_APP_BUSINESS_EVENTS_TOTAL = "app_business_events_total";
     static final String METRIC_APP_BUSINESS_EVENTS_WARN_THRESHOLDS = "app_business_events_1min_warn_thresholds";
     static final String METRIC_APP_BUSINESS_EVENTS_ERROR_THRESHOLDS = "app_business_events_1min_error_thresholds";
@@ -57,8 +65,8 @@ public class AppBusinessEventLogger implements EventLogger {
         this.meterRegistry = meterRegistry;
     }
 
-    Counter counter(AppBusinessEvent event) {
-        return this.meterRegistry.counter(METRIC_APP_BUSINESS_EVENTS_TOTAL, Tags.of("name", event.getName()));
+    private Counter counter(Tags tags) {
+        return this.meterRegistry.counter(METRIC_APP_BUSINESS_EVENTS_TOTAL, tags);
     }
 
     @Override
@@ -68,11 +76,36 @@ public class AppBusinessEventLogger implements EventLogger {
 
     @Override
     public void log(AppBusinessEvent event, double increment) {
-        this.counter(event).increment(increment);
-        event.getWarnThreshold().ifPresent(e -> this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_WARN_THRESHOLDS, Tags.of("name", event.getName()), e.getOneMinuteThreshold()));
-        event.getErrorThreshold().ifPresent(e -> this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_ERROR_THRESHOLDS, Tags.of("name", event.getName()), e.getOneMinuteThreshold()));
+        Tags tags = resolveTagsOf(event);
+        this.counter(tags).increment(increment);
+        event.getWarnThreshold().ifPresent(e -> this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_WARN_THRESHOLDS, tags, e.getOneMinuteThreshold()));
+        event.getErrorThreshold().ifPresent(e -> this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_ERROR_THRESHOLDS, tags, e.getOneMinuteThreshold()));
         if (event instanceof AppSensorEvent) {
-            this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_SENSOR_SCORE, Tags.of("name", event.getName()), ((AppSensorEvent) event).getSensorScore());
+            this.meterRegistry.gauge(METRIC_APP_BUSINESS_EVENTS_SENSOR_SCORE, resolveTagsOf(event), ((AppSensorEvent) event).getSensorScore());
+        }
+    }
+
+    private static Tags resolveTagsOf(AppBusinessEvent event) {
+        Tag eventNameTag = Tag.of("name", event.getName());
+        Map<String, String> additionalTags = event.getAdditionalTags();
+        if (additionalTags == null || additionalTags.isEmpty()) {
+            return Tags.of(eventNameTag);
+        } else {
+            return additionalTags.entrySet().stream()
+                .filter(t -> {
+                    boolean attemptsOverwriteNameTag = Objects.equals(eventNameTag.getKey(), t.getKey());
+                    if (attemptsOverwriteNameTag) {
+                        LOG.warn(
+                                "The event {} ({}) attempted to include the additional tag {}=\"{}\", " +
+                                "which would overwrite the reserved tag used for the event's name, " +
+                                "and is not allowed. The tag is discarded.",
+                                event.getName(), event.getClass().getName(), t.getKey(), t.getValue());
+                    }
+                    return !attemptsOverwriteNameTag;
+                })
+                .map(t -> Tag.of(t.getKey(), t.getValue()))
+                .reduce(Tags.empty(), Tags::and, Tags::and)
+                .and(eventNameTag);
         }
     }
 }

--- a/src/test/java/no/digipost/monitoring/event/AppBusinessEventLoggerTest.java
+++ b/src/test/java/no/digipost/monitoring/event/AppBusinessEventLoggerTest.java
@@ -18,13 +18,16 @@ package no.digipost.monitoring.event;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AppBusinessEventLoggerTest {
 
@@ -76,6 +79,36 @@ public class AppBusinessEventLoggerTest {
 
         assertThat(prometheusRegistry.scrape(), not(containsString("NaN")));
     }
+
+    @Nested
+    class AdditionalTags {
+        @Test
+        void event_name_takes_precedence_over_additional_tags() {
+            eventLogger.log(Event.DISCARDED_ADDITIONAL_NAME_TAG);
+            assertAll(
+                    () -> assertThat(prometheusRegistry.scrape(), not(containsString(Event.DISCARDED_ADDITIONAL_NAME_TAG.getAdditionalTags().get("name")))),
+                    () -> assertThat(prometheusRegistry.scrape(), containsString(Event.DISCARDED_ADDITIONAL_NAME_TAG.getName())),
+                    () -> assertThat(prometheusRegistry.scrape(), containsString(Event.DISCARDED_ADDITIONAL_NAME_TAG.getAdditionalTags().get("myTag"))));
+        }
+    }
+
+    private enum Event implements AppBusinessEvent.Informational, AppBusinessEvent.NamedAsEnum {
+        DISCARDED_ADDITIONAL_NAME_TAG(Map.of(
+                "name", "discardedValue",
+                "myTag", "myTagValue"));
+
+        final Map<String, String> additionalTags;
+
+        Event(Map<String, String> additionalTags) {
+            this.additionalTags = additionalTags;
+        }
+
+        @Override
+        public Map<String, String> getAdditionalTags() {
+            return additionalTags;
+        }
+    }
+
 
     private enum MyBusinessEvents implements AppBusinessEvent {
         VIOLATION,


### PR DESCRIPTION
Currently the tags set on events registered by `AppBusinessEventLogger` have been fixed to only include the name provided by each `AppBusinessEvent` as `name="MY_EVENT_NAME"`. This PR adds support for dynamically providing additional tags on each logged event.

Question: should the warn and error threshold be kept applied only to the fixed `name`-tag? And I guess the same goes for the App sensor score. I changed the gauges to also include additional tags, but thinking about it, maybe it makes most sense to keep these meters for _only_ the `name`-tag?

Say you count events like this:
```
{name="INVALID_LOGIN",userAgent="Firefox"}
{name="INVALID_LOGIN",userAgent="Chrome"}
```
Then you would probably be interested in the warn/error/sensor gauges to measure on only `name="INVALID_LOGIN"`, right?